### PR TITLE
add CORS headers

### DIFF
--- a/sotra-lsf-ds/Docker/Dockerfile
+++ b/sotra-lsf-ds/Docker/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 RUN pip config --user set global.progress_bar off
 RUN pip install Cython
 RUN pip install flask
+RUN pip install flask-cors
 RUN pip install ctranslate2
 RUN pip install sacremoses
 RUN pip install sentence_splitter

--- a/sotra-lsf-ds/Docker/inference_new2.py
+++ b/sotra-lsf-ds/Docker/inference_new2.py
@@ -229,8 +229,11 @@ if __name__ == "__main__":
 
     #from flask import Flask, escape, request
     from flask import Flask, request
+    from flask_cors import CORS, cross_origin
 
     app = Flask(__name__)
+    cors = CORS(app)
+    app.config['CORS_HEADERS'] = 'Content-Type'
 
     runner = FairseqCTranslateRunner()
 


### PR DESCRIPTION
Falls jemand das Backend via HTTPS von einem anderen Server aus ansprechen will, sollten wir die entsprechende Richtlinie setzen. Sonst machen die Browser Probleme.